### PR TITLE
Create ThunderLink_WIN10_64bit_Thunderbird_32bit.reg

### DIFF
--- a/ThunderLink_WIN10_64bit_Thunderbird_32bit.reg
+++ b/ThunderLink_WIN10_64bit_Thunderbird_32bit.reg
@@ -1,0 +1,14 @@
+REGEDIT4
+
+;Thunderlink Windows 10 64-bit with Thunderbird 32-bit
+
+[HKEY_CLASSES_ROOT\thunderlink]
+@="URL:thunderlink Protocol"
+"URL Protocol"=""
+
+[HKEY_CLASSES_ROOT\thunderlink\shell]
+
+[HKEY_CLASSES_ROOT\thunderlink\shell\open]
+
+[HKEY_CLASSES_ROOT\thunderlink\shell\open\command]
+@="\"C:\\Program Files (x86)\\Mozilla Thunderbird\\thunderbird.exe\" -thunderlink \"%1\""


### PR DESCRIPTION
Windows registry file for registration of the 'thunderlink' protocol on Windows 10 64-bit with Thunderbird 32-bit