### PR TITLE
Allow Thunderbird to be anywhere in PATH.

### DIFF
--- a/integration/thunderbird-tl.desktop
+++ b/integration/thunderbird-tl.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=Thunderlink Opener
 Comment=Open specific Message-ID Thunderbird
-Exec=/usr/lib/thunderbird/thunderbird -thunderlink '%u'
+Exec=thunderbird -thunderlink '%u'
 Terminal=false
 X-MultipleArgs=false
 Type=Application


### PR DESCRIPTION
> The executable program can either be specified with its full path or with the name of the executable only. If no full path is provided the executable is looked up in the $PATH environment variable used by the desktop environment.
https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html