### PR TITLE
Added path to mimeapps.list in newer systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ ThunderLinks are durable even if you file the message. They are based on the uni
    <li>Add the handler: `echo "x-scheme-handler/thunderlink=thunderbird-tl.desktop" >> ~/.local/share/applications/mimeapps.list`</li>
    </ol>
    </ol>
+   
+   `mimeapps.list` might be placed here: `~/.config/mimeapps.list`
 
    <b>Mac:</b>
    ----------


### PR DESCRIPTION
According to https://wiki.archlinux.org/index.php/XDG_MIME_Applications#mimeapps.list the location of the file is deprecated.
I added the new path.