### PR TITLE
Do not display desktop files in menus.

### DIFF
--- a/integration/thunderbird-message-tl.desktop
+++ b/integration/thunderbird-message-tl.desktop
@@ -11,3 +11,4 @@ Categories=Application;Network;Email;
 MimeType=x-scheme-handler/thunderlink;
 StartupNotify=true
 Actions=Compose;Contacts
+NoDisplay=true

--- a/integration/thunderbird-tl.desktop
+++ b/integration/thunderbird-tl.desktop
@@ -11,3 +11,4 @@ Categories=Application;Network;Email;
 MimeType=x-scheme-handler/thunderlink;
 StartupNotify=true
 Actions=Compose;Contacts
+NoDisplay=true


### PR DESCRIPTION
This is a minor improvement to prevent the Thunderlink handler from showing up in menus. The [FreeDesktop spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html) has this to say:

> `NoDisplay` means "this application exists, but don't display it in the menus". This can be useful to e.g. associate this application with MIME types, so that it gets launched from a file manager (or other apps), without having a menu entry for it (there are tons of good reasons for this, including e.g. the `netscape -remote`, or `kfmclient openURL` kind of stuff).

I don't think opening Thunderbird from a menu via the Thunderlink handler is likely to cause any issues, but I find it less confusing when the handler is hidden.